### PR TITLE
Add Google Scholar link to About page for latest publications

### DIFF
--- a/about.html
+++ b/about.html
@@ -195,7 +195,8 @@
           <div class="col-xs-12">
             <h3 style="font-family: Lettera; color:#000; font-size:large;">Research Publications & Conferences</h3>
             <ul style="font-family: Noto Sans Mono; color:#000; font-size:small;" class="list-unstyled"> 
-              <li><a href="https://ui.adsabs.harvard.edu/abs/2024AGUFMA51U..197C/abstract" title=""><b>Increased Incidence of Localised Monsoon Droughts in the Indo-Gangetic Plains</b></a></li>
+              <li><b>Latest publication details:</b> <a href="https://scholar.google.com/citations?user=M2saBgYAAAAJ&hl=en" title="Google Scholar profile">Google Scholar profile</a></li>
+              <li style="margin-top: 10px;"><a href="https://ui.adsabs.harvard.edu/abs/2024AGUFMA51U..197C/abstract" title=""><b>Increased Incidence of Localised Monsoon Droughts in the Indo-Gangetic Plains</b></a></li>
               <li><b>Sarat Chandra</b>, Venugopal Vuruputur, Sekhar Muddu, AGU Fall Meeting 2024, Washington, D.C., USA <span class="fi fi-us"></span></li>
               <li style="margin-top: 10px;"><a href="https://scholar.google.com/citations?view_op=view_citation&hl=en&user=M2saBgYAAAAJ&citation_for_view=M2saBgYAAAAJ:j3f4tGmQtD8C" title=""><b>Bundelkhand's Paradox: Two Droughts, One Monsoon</b></a></li>
               <li><b>C Sarat</b>, V Venugopal, S Muddu, 21st Annual Meeting of the Asia Oceania Geosciences Society, Pyeongchang, South Korea,  2024 <span class="fi fi-kr"></span></li>


### PR DESCRIPTION
### Motivation
- Make it easy for visitors to find the most up-to-date publication information by pointing the Research Publications section to the Google Scholar profile.

### Description
- Added a new top list item in `about.html` under the “Research Publications & Conferences” heading that links to the Google Scholar profile (`https://scholar.google.com/citations?user=M2saBgYAAAAJ&hl=en`) and adjusted spacing for the following list item.

### Testing
- Performed a repository status check, a file diff of `about.html`, and inspected the updated lines (188–210) to confirm only the intended HTML was changed, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036f811f3c83259fc9eb6f53a12d18)