### PR TITLE
Add Climate Dynamics publication and IWM-8 entry to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -196,6 +196,10 @@
             <h3 style="font-family: Lettera; color:#000; font-size:large;">Research Publications & Conferences</h3>
             <ul style="font-family: Noto Sans Mono; color:#000; font-size:small;" class="list-unstyled"> 
               <li><b>Latest publication details:</b> <a href="https://scholar.google.com/citations?user=M2saBgYAAAAJ&hl=en" title="Google Scholar profile">Google Scholar profile</a></li>
+              <li style="margin-top: 10px;"><a href="https://doi.org/10.1007/s00382-025-07955-7" title=""><b>The subseasonal evolution of Indian rainfall dipole and its local impact in recent decades</b></a></li>
+              <li><b>V Venugopal</b>, S Muddu, Climate Dynamics, 2026 (DOI: 10.1007/s00382-025-07955-7)</li>
+              <li style="margin-top: 10px;"><a href="https://wmo-iwm8.tropmet.res.in/poster-file/NTQ2OTg3MTk3" title=""><b>Recent Increase in Occurrence of Localised Monsoon Droughts in the Indo-Gangetic Plains</b></a></li>
+              <li><b>Sarat Chandra Chamarthi</b>, V Venugopal, S Muddu, International Workshop on Monsoons (IWM-8), 2025</li>
               <li style="margin-top: 10px;"><a href="https://ui.adsabs.harvard.edu/abs/2024AGUFMA51U..197C/abstract" title=""><b>Increased Incidence of Localised Monsoon Droughts in the Indo-Gangetic Plains</b></a></li>
               <li><b>Sarat Chandra</b>, Venugopal Vuruputur, Sekhar Muddu, AGU Fall Meeting 2024, Washington, D.C., USA <span class="fi fi-us"></span></li>
               <li style="margin-top: 10px;"><a href="https://scholar.google.com/citations?view_op=view_citation&hl=en&user=M2saBgYAAAAJ&citation_for_view=M2saBgYAAAAJ:j3f4tGmQtD8C" title=""><b>Bundelkhand's Paradox: Two Droughts, One Monsoon</b></a></li>


### PR DESCRIPTION
### Motivation
- Keep the About page publications list current by adding the newly published Climate Dynamics paper (DOI: `10.1007/s00382-025-07955-7`) and a missing online conference/poster entry (IWM-8, 2025).

### Description
- Updated `about.html` in the **Research Publications & Conferences** section to add a DOI link for "The subseasonal evolution of Indian rainfall dipole and its local impact in recent decades" pointing to `https://doi.org/10.1007/s00382-025-07955-7`.
- Added a bibliographic line for `V Venugopal, S Muddu, Climate Dynamics, 2026 (DOI: 10.1007/s00382-025-07955-7)` and inserted an IWM-8 (2025) poster entry linking to `https://wmo-iwm8.tropmet.res.in/poster-file/NTQ2OTg3MTk3` with the corresponding author/conference line for `Sarat Chandra Chamarthi`.
- Preserved existing list items and placed the new entries near the top for visibility.

### Testing
- Verified the updated HTML snippet with `sed -n '150,260p' about.html`, which completed successfully and showed the inserted list items.
- Inspected the file region with `nl -ba about.html | sed -n '190,220p'`, which showed the expected new lines were present.
- Confirmed the change set for `about.html` with `git diff -- about.html`, which displayed the four inserted lines as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03d08882d083258d271606932ae9c1)