### PR TITLE
Update About page with recent publications and spacing tweaks

### DIFF
--- a/about.html
+++ b/about.html
@@ -195,7 +195,10 @@
           <div class="col-xs-12">
             <h3 style="font-family: Lettera; color:#000; font-size:large;">Research Publications & Conferences</h3>
             <ul style="font-family: Noto Sans Mono; color:#000; font-size:small;" class="list-unstyled"> 
-              <li><b>Latest publication details:</b> <a href="https://scholar.google.com/citations?user=M2saBgYAAAAJ&hl=en" title="Google Scholar profile">Google Scholar profile</a></li>
+              <li style="margin-top: 10px;"><a href="https://doi.org/10.1007/s00382-025-07955-7" title=""><b>The subseasonal evolution of Indian rainfall dipole and its local impact in recent decades</b></a></li>
+              <li><b>Sarat Chandra Chamarthi</b>, V Venugopal, S Muddu, Climate Dynamics, 2026 (DOI: 10.1007/s00382-025-07955-7)</li>
+              <li style="margin-top: 10px;"><a href="https://wmo-iwm8.tropmet.res.in/poster-file/NTQ2OTg3MTk3" title=""><b>Recent Increase in Occurrence of Localised Monsoon Droughts in the Indo-Gangetic Plains</b></a></li>
+              <li><b>Sarat Chandra Chamarthi</b>, V Venugopal, S Muddu, International Workshop on Monsoons (IWM-8), 2025</li>
               <li style="margin-top: 10px;"><a href="https://ui.adsabs.harvard.edu/abs/2024AGUFMA51U..197C/abstract" title=""><b>Increased Incidence of Localised Monsoon Droughts in the Indo-Gangetic Plains</b></a></li>
               <li><b>Sarat Chandra</b>, Venugopal Vuruputur, Sekhar Muddu, AGU Fall Meeting 2024, Washington, D.C., USA <span class="fi fi-us"></span></li>
               <li style="margin-top: 10px;"><a href="https://scholar.google.com/citations?view_op=view_citation&hl=en&user=M2saBgYAAAAJ&citation_for_view=M2saBgYAAAAJ:j3f4tGmQtD8C" title=""><b>Bundelkhand's Paradox: Two Droughts, One Monsoon</b></a></li>


### PR DESCRIPTION
### Motivation

- Refresh the Research Publications & Conferences section in `about.html` to include recently published papers and conference contributions and to improve vertical spacing for readability.

### Description

- Added a DOI-linked entry for the 2026 Climate Dynamics paper and a corresponding citation line. 
- Added an IWM-8 2025 poster entry with link and its citation line. 
- Added `style="margin-top: 10px;"` to several `<li>` elements for consistent spacing and removed the previous `Latest publication details` Google Scholar list item in favor of explicit publication entries.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03d08882d083258d271606932ae9c1)